### PR TITLE
Fix global QUIC engine cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ COPY network_utils.py ./
 COPY ui_server.py ./
 COPY p2p_protocol.py ./
 COPY rendezvous_client.py ./
+COPY cert.pem ./
+COPY key.pem ./
 COPY index.html ./
 
 # Make port 8080 available to the world outside this container (Cloud Run default)

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -14,6 +14,8 @@ RUN pip install --no-cache-dir --prefer-binary -r requirements.txt
 # Using the wildcard ensures new modules are automatically included without needing manual Dockerfile edits.
 COPY *.py ./
 COPY index.html ./
+COPY cert.pem ./
+COPY key.pem ./
 # If you have other ancillary files (e.g., certificates, static assets) place additional COPY commands here.
 
 # This worker doesn't run a Gunicorn server anymore; it runs the main.py script directly.

--- a/p2p_protocol.py
+++ b/p2p_protocol.py
@@ -99,9 +99,12 @@ class P2PUDPProtocol(asyncio.DatagramProtocol):
                         if self.associated_quic_tunnel is tunnel_instance_being_closed:
                             print(f"Worker '{self.worker_id}': Associated server-side QuicTunnel for {tunnel_instance_being_closed.peer_addr} closed. Clearing reference.")
                             self.associated_quic_tunnel = None
-                        # Note: This does not automatically set the global AppContext engine to None.
-                        # That should be handled by a callback provided by main.py/AppContext if needed,
-                        # when this tunnel was set as the global one.
+                        if self.get_quic_engine() is tunnel_instance_being_closed:
+                            print(
+                                f"Worker '{self.worker_id}': Server-side QuicTunnel that was global for {tunnel_instance_being_closed.peer_addr} closed. Clearing global reference."
+                            )
+                            self.set_quic_engine(None)
+                        # Note: Main context is notified here via set_quic_engine if this tunnel was the global one.
                     return server_tunnel_on_close_callback
 
                 # Create the new server-side tunnel instance first

--- a/quic_tunnel.py
+++ b/quic_tunnel.py
@@ -258,7 +258,7 @@ class QuicTunnel:
                                 )
                                 # Extra debug information for troubleshooting
                                 print(
-                                    f"Worker '{self.worker_id}': Debug - original frame was: {frame}"
+                                    f"Worker '{self.worker_id}': Debug - original frame was: {frame_str}"
                                 )
                                 continue
                             echoed_payload = parts[3] if len(parts) > 3 else ""


### PR DESCRIPTION
## Summary
- keep QUIC certificate/key in worker images
- clear global engine when server tunnel closes

## Testing
- `python3 -m py_compile p2p_protocol.py quic_tunnel.py`
- `python3 -m unittest -v tests/test_network_utils.py`