### PR TITLE
Add missing edge case handling in network and tunnel logic

### DIFF
--- a/network_utils.py
+++ b/network_utils.py
@@ -30,6 +30,9 @@ def is_probable_quic_datagram(blob: bytes) -> bool:
     #    bit pattern as many printable ASCII characters (e.g. 'P' = 0x50 has
     #    bit 6 set).  Explicitly filter those out before running the generic
     #    bit-tests below.
+    if not blob:
+        return False
+
     ascii_exclusions = (
         b"P2P_HOLE_PUNCH_PING_FROM_",
         b"P2P_HOLE_PUNCH_PONG_FROM_",

--- a/quic_tunnel.py
+++ b/quic_tunnel.py
@@ -410,7 +410,8 @@ class QuicTunnel:
                 self._quic_stream_id = None
 
     async def _local_tcp_to_quic_loop(self):
-        if not self._local_tcp_reader or not self._quic_stream_id: return
+        if self._local_tcp_reader is None or self._quic_stream_id is None:
+            return
         try:
             while True:
                 data = await self._local_tcp_reader.read(4096)

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -32,5 +32,8 @@ class TestIsProbableQuicDatagram(unittest.TestCase):
     def test_non_quic_binary(self):
         self.assertFalse(network_utils.is_probable_quic_datagram(b"\x05\x01\x02"))
 
+    def test_empty_blob(self):
+        self.assertFalse(network_utils.is_probable_quic_datagram(b""))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_quic_tunnel.py
+++ b/tests/test_quic_tunnel.py
@@ -1,0 +1,108 @@
+import asyncio
+import sys
+import types
+import unittest
+
+# Stub external modules so quic_tunnel can be imported without optional deps
+for mod_name in [
+    "aioquic",
+    "aioquic.quic",
+    "aioquic.quic.configuration",
+    "aioquic.quic.connection",
+    "aioquic.quic.events",
+    "aioquic.quic.packet",
+    "cryptography",
+    "cryptography.x509",
+    "cryptography.x509.oid",
+    "cryptography.hazmat.primitives",
+    "cryptography.hazmat.primitives.hashes",
+    "cryptography.hazmat.primitives.serialization",
+    "cryptography.hazmat.primitives.asymmetric",
+    "cryptography.hazmat.primitives.asymmetric.rsa",
+]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+crypt_mod = sys.modules['cryptography']
+crypt_mod.__path__ = []
+crypt_mod.__spec__ = types.SimpleNamespace(submodule_search_locations=[])
+x509_mod = sys.modules['cryptography.x509']
+x509_mod.__package__ = 'cryptography'
+sys.modules['cryptography'].x509 = x509_mod
+oid_mod = sys.modules['cryptography.x509.oid']
+class NameOID:
+    COMMON_NAME = object()
+oid_mod.NameOID = NameOID
+
+# Stub websockets so ui_server can be imported
+ws_mod = types.ModuleType('websockets')
+from importlib.machinery import ModuleSpec
+ws_mod.__path__ = []
+ws_mod.__spec__ = ModuleSpec('websockets', loader=None, is_package=True)
+ws_mod.WebSocketServerProtocol = object
+ws_mod.WebSocketClientProtocol = object
+ws_mod.exceptions = types.SimpleNamespace(ConnectionClosed=Exception)
+http_mod = types.ModuleType('websockets.http')
+http_mod.__package__ = 'websockets'
+http_mod.__spec__ = ModuleSpec('websockets.http', loader=None)
+ws_mod.http = http_mod
+class Headers(list):
+    pass
+http_mod.Headers = Headers
+sys.modules['websockets'] = ws_mod
+sys.modules['websockets.http'] = http_mod
+
+# Minimal stubs used by quic_tunnel
+class QuicConfiguration:
+    def __init__(self, is_client=False, alpn_protocols=None, idle_timeout=0):
+        self.is_client = is_client
+        self.connection_id_length = 8
+    def load_cert_chain(self, *a, **kw):
+        pass
+
+class QuicConnection:
+    def __init__(self, *a, **kw):
+        self.sent = []
+        self.next_id = 0
+    def connect(self, addr, now=None):
+        pass
+    def datagrams_to_send(self, now=None):
+        return []
+    def receive_datagram(self, data, addr, now=None):
+        pass
+    def next_event(self):
+        return None
+    def get_next_available_stream_id(self, is_unidirectional=False):
+        self.next_id += 1
+        return self.next_id - 1
+    def send_stream_data(self, stream_id, data, end_stream=False):
+        self.sent.append((stream_id, data, end_stream))
+    def get_timer(self):
+        return None
+    def handle_timer(self, now=None):
+        pass
+    def close(self, error_code=0, reason_phrase=""):
+        pass
+
+sys.modules["aioquic.quic.configuration"].QuicConfiguration = QuicConfiguration
+sys.modules["aioquic.quic.connection"].QuicConnection = QuicConnection
+
+class DummyEvent: pass
+for name in ["StreamDataReceived", "HandshakeCompleted", "ConnectionTerminated", "PingAcknowledged"]:
+    setattr(sys.modules["aioquic.quic.events"], name, DummyEvent)
+
+class QuicErrorCode:
+    INTERNAL_ERROR = 1
+sys.modules["aioquic.quic.packet"].QuicErrorCode = QuicErrorCode
+
+from ui_server import broadcast_to_all_ui_clients  # uses stub websockets if not installed
+from quic_tunnel import QuicTunnel
+
+
+class TestQuicTunnelSendData(unittest.TestCase):
+    def test_send_app_data_opens_stream(self):
+        qt = QuicTunnel("worker", ("127.0.0.1", 9999), lambda d, a: None, True)
+        self.assertIsNone(qt._quic_stream_id)
+        asyncio.run(qt.send_app_data(b"hello"))
+        self.assertIsNotNone(qt._quic_stream_id)
+        self.assertEqual(qt.quic_connection.sent[0][1], b"hello")

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,0 +1,122 @@
+import asyncio
+import json
+import sys
+import types
+import unittest
+from importlib.machinery import ModuleSpec
+
+# Stub websockets module with minimal features for ui_server import
+ws_mod = types.ModuleType('websockets')
+ws_mod.__path__ = []
+ws_mod.__spec__ = ModuleSpec('websockets', loader=None, is_package=True)
+class ConnectionClosed(Exception):
+    pass
+ws_mod.exceptions = types.SimpleNamespace(ConnectionClosed=ConnectionClosed)
+
+class WebSocketServerProtocol:
+    def __init__(self):
+        self.sent = []
+        self.recv_queue = asyncio.Queue()
+        self.remote_address = ('test', 0)
+        self.closed = False
+    async def send(self, data):
+        self.sent.append(data)
+    def __aiter__(self):
+        return self
+    async def __anext__(self):
+        if self.closed and self.recv_queue.empty():
+            raise ConnectionClosed()
+        return await self.recv_queue.get()
+    async def close(self, code=1000, reason=""):
+        self.closed = True
+
+ws_mod.WebSocketServerProtocol = WebSocketServerProtocol
+ws_mod.WebSocketClientProtocol = WebSocketServerProtocol
+
+http_mod = types.ModuleType('websockets.http')
+http_mod.__package__ = 'websockets'
+http_mod.__spec__ = ModuleSpec('websockets.http', loader=None)
+ws_mod.http = http_mod
+class Headers(list):
+    pass
+http_mod.Headers = Headers
+
+sys.modules['websockets'] = ws_mod
+sys.modules['websockets.http'] = http_mod
+
+from ui_server import ui_websocket_handler, process_http_request, broadcast_to_all_ui_clients
+
+
+def dummy_get_p2p_info():
+    return (None, None, None)
+
+def dummy_get_rendezvous_ws():
+    return None
+
+async def dummy_benchmark_sender(*a, **kw):
+    pass
+
+async def dummy_delayed_exit(*a, **kw):
+    pass
+
+async def dummy_discover_stun(*a, **kw):
+    return None
+
+def dummy_update_main(*a, **kw):
+    pass
+
+def dummy_get_quic_engine():
+    return None
+
+class FakeWebSocket(WebSocketServerProtocol):
+    pass
+
+class TestUIServer(unittest.IsolatedAsyncioTestCase):
+    async def test_process_http_request_health(self):
+        code, headers, body = await process_http_request('/health', Headers())
+        self.assertEqual(code, 200)
+        self.assertIn(b'OK', body)
+
+    async def test_ui_websocket_handler_basic(self):
+        ws = FakeWebSocket()
+        await ws.recv_queue.put(json.dumps({'type': 'ui_client_hello'}))
+        handler_task = asyncio.create_task(
+            ui_websocket_handler(
+                ws,
+                '/ui_ws',
+                'worker1',
+                dummy_get_p2p_info,
+                dummy_get_rendezvous_ws,
+                8081,
+                'stun.example',
+                19302,
+                dummy_benchmark_sender,
+                dummy_delayed_exit,
+                dummy_discover_stun,
+                dummy_update_main,
+                dummy_get_quic_engine,
+            )
+        )
+        await asyncio.sleep(0.05)
+        ws.closed = True
+        handler_task.cancel()
+        try:
+            await handler_task
+        except asyncio.CancelledError:
+            pass
+        self.assertTrue(ws.sent)
+        first = json.loads(ws.sent[0])
+        self.assertEqual(first['type'], 'init_info')
+
+    async def test_broadcast(self):
+        ws1 = FakeWebSocket()
+        ws2 = FakeWebSocket()
+        from ui_server import ui_websocket_clients
+        ui_websocket_clients.add(ws1)
+        ui_websocket_clients.add(ws2)
+        await broadcast_to_all_ui_clients({'foo': 'bar'})
+        self.assertEqual(json.loads(ws1.sent[0]), {'foo': 'bar'})
+        self.assertEqual(json.loads(ws2.sent[0]), {'foo': 'bar'})
+        ws1.closed = True
+        ws2.closed = True
+        ui_websocket_clients.clear()


### PR DESCRIPTION
## Summary
- fix IndexError in `is_probable_quic_datagram` by returning False for empty datagrams
- ensure QUIC stream with ID 0 is handled in `_local_tcp_to_quic_loop`
- add unit test to cover empty datagrams

## Testing
- `python -m unittest discover -v tests`