### PR TITLE
Improve logging for QUIC UDP issues

### DIFF
--- a/p2p_protocol.py
+++ b/p2p_protocol.py
@@ -71,7 +71,12 @@ class P2PUDPProtocol(asyncio.DatagramProtocol):
                 print(
                     f"Worker '{self.worker_id}': Feeding datagram to QUIC tunnel at {time.monotonic():.4f}"
                 )
-                asyncio.create_task(active_tunnel.feed_datagram(data, addr))
+                task = asyncio.create_task(active_tunnel.feed_datagram(data, addr))
+                task.add_done_callback(
+                    lambda t, peer=addr: print(
+                        f"Worker '{self.worker_id}': feed_datagram task exception from {peer}: {t.exception()}"
+                    ) if t.exception() else None
+                )
                 return
             # If not a QUIC datagram, it falls through to JSON/benchmark processing below,
             # using the peer context (get_current_p2p_peer_id/addr) for those messages.

--- a/quic_tunnel.py
+++ b/quic_tunnel.py
@@ -240,9 +240,17 @@ class QuicTunnel:
     def _transmit_pending_udp(self):
         for data, addr in self.quic_connection.datagrams_to_send(now=time.time()):
             print(
-                f"Worker '{self.worker_id}': _transmit_pending_udp sending {len(data)} bytes to {addr}"
+                f"Worker '{self.worker_id}': _transmit_pending_udp about to send {len(data)} bytes to {addr}"
             )
-            self.udp_sender(data, addr)
+            try:
+                self.udp_sender(data, addr)
+                print(
+                    f"Worker '{self.worker_id}': _transmit_pending_udp send complete to {addr}"
+                )
+            except Exception as e_send:
+                print(
+                    f"Worker '{self.worker_id}': Error calling udp_sender for {addr}: {e_send}"
+                )
 
     def _process_quic_events(self):
         event = self.quic_connection.next_event()

--- a/rendezvous_client.py
+++ b/rendezvous_client.py
@@ -68,9 +68,19 @@ async def start_udp_hole_punch(app_context: Any, peer_udp_ip: str, peer_udp_port
                 # Need to get fresh p2p_udp_transport via app_context if it can change
                 current_p2p_transport = app_context.get_p2p_transport()
                 if current_p2p_transport and not current_p2p_transport.is_closing():
-                    current_p2p_transport.sendto(data_to_send, destination_addr)
+                    try:
+                        print(
+                            f"Worker '{worker_id}': UDP_SENDER_FOR_QUIC sending {len(data_to_send)} bytes to {destination_addr} via {current_p2p_transport}"
+                        )
+                        current_p2p_transport.sendto(data_to_send, destination_addr)
+                    except Exception as e_send:
+                        print(
+                            f"Worker '{worker_id}': UDP_SENDER_FOR_QUIC error sending to {destination_addr}: {e_send}"
+                        )
                 else:
-                    print(f"Worker '{worker_id}': QUIC UDP sender: P2P transport not available or closing. Cannot send.")
+                    print(
+                        f"Worker '{worker_id}': QUIC UDP sender: P2P transport not available or closing. Cannot send data to {destination_addr}."
+                    )
 
             new_quic_engine = QuicTunnel_cls(
                 worker_id_val=worker_id,


### PR DESCRIPTION
## Summary
- extend `_transmit_pending_udp` with detailed logging and exception handling
- add diagnostics for QUIC UDP sender
- log exceptions from async `feed_datagram`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*