### PR TITLE
Implement list protocol and NAT traversal

### DIFF
--- a/go-libp2p-holepunch-services/README.md
+++ b/go-libp2p-holepunch-services/README.md
@@ -49,10 +49,11 @@ cd go-libp2p-holepunch-services/rendezvous && go test -v
 cd ../worker && go test -v
 ```
 
-## Next steps
+## Features
 
-* Implement `/list` protocol so workers can discover each other.
-* Enable AutoNAT / AutoRelay and attempt direct or relayed connections.
+* `/list` protocol allows workers to discover peers directly from the rendezvous service.
+* Workers use libp2p's hole punching and AutoRelay to form direct or relayed connections.
+  Set `LIBP2P_RELAY_BOOTSTRAP` to a relay multiaddr if you provide one.
 * Containerise each service (`Dockerfile`) and deploy to Cloud Run behind Cloud NAT.
 
 ## One-command Cloud Run deploy (experimental)

--- a/go-libp2p-holepunch-services/rendezvous/main_test.go
+++ b/go-libp2p-holepunch-services/rendezvous/main_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	libp2p "github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/stretchr/testify/require"
 	ma "github.com/multiformats/go-multiaddr"
-	libp2p "github.com/libp2p/go-libp2p"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateLibp2pHost(t *testing.T) {
@@ -211,4 +211,57 @@ func TestWorkerRegistration(t *testing.T) {
 	if string(ack) != "ACK" {
 		t.Fatalf("unexpected ACK payload: %q", string(ack))
 	}
-} 
+}
+
+// TestListProtocolReturnsPeers verifies that the listHandler sends registered peers.
+func TestListProtocolReturnsPeers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Rendezvous host
+	rvHost, err := createHost(ctx, 0)
+	require.NoError(t, err)
+	defer rvHost.Close()
+	rvHost.SetStreamHandler(ProtocolIDForRegistration, simpleRegistrationHandlerForTest)
+	rvHost.SetStreamHandler(ProtocolIDForPeerList, listHandler)
+
+	// worker1
+	w1, err := libp2p.New()
+	require.NoError(t, err)
+	defer w1.Close()
+
+	// worker2
+	w2, err := libp2p.New()
+	require.NoError(t, err)
+	defer w2.Close()
+
+	rvInfo := peer.AddrInfo{ID: rvHost.ID(), Addrs: rvHost.Addrs()}
+	require.NoError(t, w1.Connect(ctx, rvInfo))
+	s, err := w1.NewStream(ctx, rvHost.ID(), ProtocolIDForRegistration)
+	require.NoError(t, err)
+	io.ReadFull(s, make([]byte, 3))
+	s.Close()
+
+	require.NoError(t, w2.Connect(ctx, rvInfo))
+	s2, err := w2.NewStream(ctx, rvHost.ID(), ProtocolIDForRegistration)
+	require.NoError(t, err)
+	io.ReadFull(s2, make([]byte, 3))
+	s2.Close()
+
+	// w1 requests list
+	listStream, err := w1.NewStream(ctx, rvHost.ID(), ProtocolIDForPeerList)
+	require.NoError(t, err)
+	data, err := io.ReadAll(listStream)
+	require.NoError(t, err)
+	listStream.Close()
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.GreaterOrEqual(t, len(lines), 1)
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, w2.ID().String()) {
+			found = true
+		}
+	}
+	require.True(t, found, "expected w2 in peer list")
+}


### PR DESCRIPTION
## Summary
- add `/list` protocol to rendezvous service for peer discovery
- enable hole punching and AutoRelay in worker
- worker now fetches peers via the list protocol and dials them
- document new features and relay bootstrap var
- add unit tests covering list protocol and new worker behaviour

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*