### PR TITLE
Add web chat demo

### DIFF
--- a/deploy_demo_cloud_run.sh
+++ b/deploy_demo_cloud_run.sh
@@ -38,7 +38,7 @@ shift || true
 if [[ ${1:-} =~ ^[0-9]+$ ]]; then
   NUM_WORKERS=$1; shift
 else
-  NUM_WORKERS=1
+  NUM_WORKERS=3
 fi
 
 echo "Will start $NUM_WORKERS worker instance(s)."
@@ -62,7 +62,8 @@ build_and_push() {
   gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 
   # local buildx build & push
-  docker buildx build --no-cache --pull --platform linux/amd64 -t "$image" --push "$dir"
+  # docker buildx build --no-cache --pull --platform linux/amd64 -t "$image" --push "$dir"
+  docker buildx build --pull --platform linux/amd64 -t "$image" --push "$dir"
 
   echo "$image"
 }

--- a/go-libp2p-holepunch-services/README.md
+++ b/go-libp2p-holepunch-services/README.md
@@ -49,10 +49,11 @@ cd go-libp2p-holepunch-services/rendezvous && go test -v
 cd ../worker && go test -v
 ```
 
-## Next steps
+## Features
 
-* Implement `/list` protocol so workers can discover each other.
-* Enable AutoNAT / AutoRelay and attempt direct or relayed connections.
+* `/list` protocol allows workers to discover peers directly from the rendezvous service.
+* Workers use libp2p's hole punching and AutoRelay to form direct or relayed connections.
+  Set `LIBP2P_RELAY_BOOTSTRAP` to a relay multiaddr if you provide one.
 * Containerise each service (`Dockerfile`) and deploy to Cloud Run behind Cloud NAT.
 
 ## One-command Cloud Run deploy (experimental)
@@ -95,3 +96,7 @@ gcloud run jobs create worker-copy --image gcr.io/<project>/go-libp2p-holepunch-
 
 The script is a *convenience helper* — feel free to adjust it to your CI/CD
 pipeline or replace it with Terraform. 
+## Browser demo
+
+A simple web interface lives in [`webdemo/index.html`](webdemo/index.html). Serve this directory with any static file server and open the page in two browser windows. Enter the rendezvous multiaddress printed by the service and click **Connect**. Once a second peer joins you can exchange chat messages and watch the hole punching attempts in the browser console.
+

--- a/go-libp2p-holepunch-services/rendezvous/main_test.go
+++ b/go-libp2p-holepunch-services/rendezvous/main_test.go
@@ -222,7 +222,7 @@ func TestListProtocolReturnsPeers(t *testing.T) {
 	rvHost, err := createHost(ctx, 0)
 	require.NoError(t, err)
 	defer rvHost.Close()
-	rvHost.SetStreamHandler(ProtocolIDForRegistration, simpleRegistrationHandlerForTest)
+	rvHost.SetStreamHandler(ProtocolIDForRegistration, registrationHandler)
 	rvHost.SetStreamHandler(ProtocolIDForPeerList, listHandler)
 
 	// worker1

--- a/go-libp2p-holepunch-services/rendezvous/main_test.go
+++ b/go-libp2p-holepunch-services/rendezvous/main_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	libp2p "github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/stretchr/testify/require"
 	ma "github.com/multiformats/go-multiaddr"
-	libp2p "github.com/libp2p/go-libp2p"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateLibp2pHost(t *testing.T) {
@@ -211,4 +211,57 @@ func TestWorkerRegistration(t *testing.T) {
 	if string(ack) != "ACK" {
 		t.Fatalf("unexpected ACK payload: %q", string(ack))
 	}
-} 
+}
+
+// TestListProtocolReturnsPeers verifies that the listHandler sends registered peers.
+func TestListProtocolReturnsPeers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Rendezvous host
+	rvHost, err := createHost(ctx, 0)
+	require.NoError(t, err)
+	defer rvHost.Close()
+	rvHost.SetStreamHandler(ProtocolIDForRegistration, simpleRegistrationHandlerForTest)
+	rvHost.SetStreamHandler(ProtocolIDForPeerList, listHandler)
+
+	// worker1
+	w1, err := libp2p.New()
+	require.NoError(t, err)
+	defer w1.Close()
+
+	// worker2
+	w2, err := libp2p.New()
+	require.NoError(t, err)
+	defer w2.Close()
+
+	rvInfo := peer.AddrInfo{ID: rvHost.ID(), Addrs: rvHost.Addrs()}
+	require.NoError(t, w1.Connect(ctx, rvInfo))
+	s, err := w1.NewStream(ctx, rvHost.ID(), ProtocolIDForRegistration)
+	require.NoError(t, err)
+	io.ReadFull(s, make([]byte, 3))
+	s.Close()
+
+	require.NoError(t, w2.Connect(ctx, rvInfo))
+	s2, err := w2.NewStream(ctx, rvHost.ID(), ProtocolIDForRegistration)
+	require.NoError(t, err)
+	io.ReadFull(s2, make([]byte, 3))
+	s2.Close()
+
+	// w1 requests list
+	listStream, err := w1.NewStream(ctx, rvHost.ID(), ProtocolIDForPeerList)
+	require.NoError(t, err)
+	data, err := io.ReadAll(listStream)
+	require.NoError(t, err)
+	listStream.Close()
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.GreaterOrEqual(t, len(lines), 1)
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, w2.ID().String()) {
+			found = true
+		}
+	}
+	require.True(t, found, "expected w2 in peer list")
+}

--- a/go-libp2p-holepunch-services/webdemo/index.html
+++ b/go-libp2p-holepunch-services/webdemo/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>libp2p Hole Punch Chat</title>
+  <style>
+    body { font-family: sans-serif; max-width: 700px; margin: auto; }
+    textarea { width: 100%; height: 200px; }
+  </style>
+</head>
+<body>
+  <h1>libp2p Hole Punch Chat</h1>
+  <label>Rendezvous multiaddr:
+    <input id="rv" style="width:90%" placeholder="/ip4/1.2.3.4/tcp/40001/ws/p2p/..." />
+  </label>
+  <button id="connect">Connect</button>
+  <div id="status"></div>
+  <textarea id="log" readonly></textarea><br>
+  <input id="msg" style="width:80%" placeholder="type a message" />
+  <button id="send" disabled>Send</button>
+
+<script type="module">
+import { createLibp2p } from 'https://unpkg.com/libp2p@0.46.6/dist/index.min.js?module'
+import { webSockets } from 'https://unpkg.com/@libp2p/websockets@0.17.0/dist/index.min.js?module'
+import { webRTC } from 'https://unpkg.com/@libp2p/webrtc@0.17.0/dist/index.min.js?module'
+import { noise } from 'https://unpkg.com/@chainsafe/libp2p-noise@11.0.0/dist/index.min.js?module'
+import { mplex } from 'https://unpkg.com/@libp2p/mplex@0.16.0/dist/index.min.js?module'
+import { multiaddr } from 'https://unpkg.com/@multiformats/multiaddr@11.1.0/dist/index.min.js?module'
+
+let node
+let conn
+const status = document.getElementById('status')
+const logBox = document.getElementById('log')
+
+function log (msg) {
+  logBox.value += msg + '\n'
+  logBox.scrollTop = logBox.scrollHeight
+}
+
+document.getElementById('connect').onclick = async () => {
+  const rv = document.getElementById('rv').value.trim()
+  if (!rv) return
+  status.textContent = 'starting libp2p...'
+  node = await createLibp2p({
+    transports: [webSockets(), webRTC()],
+    streamMuxers: [mplex()],
+    connectionEncryption: [noise()]
+  })
+  await node.start()
+  status.textContent = `peer id: ${node.peerId.toString()}`
+  log('node started with id ' + node.peerId.toString())
+
+  node.handle('/chat/1.0.0', async ({ stream }) => {
+    for await (const chunk of stream.source) {
+      log('peer: ' + new TextDecoder().decode(chunk))
+    }
+  })
+
+  const ma = multiaddr(rv)
+  const reg = await node.dialProtocol(ma, '/holepunch/rendezvous/1.0.0')
+  // send empty payload just to trigger ACK
+  await reg.sink((async function * () { yield new Uint8Array() })())
+  await reg.source.getReader().read()
+  reg.close?.()
+
+  const ls = await node.dialProtocol(ma, '/holepunch/list/1.0.0')
+  const { value } = await ls.source.getReader().read()
+  const peers = new TextDecoder().decode(value).trim().split('\n').filter(Boolean)
+  if (peers.length) {
+    const peerMa = multiaddr(peers[0])
+    conn = await node.dialProtocol(peerMa, '/chat/1.0.0')
+    log('connected to peer ' + peers[0])
+  } else {
+    log('no peers found; waiting for another peer to connect')
+  }
+  ls.close?.()
+  document.getElementById('send').disabled = false
+}
+
+document.getElementById('send').onclick = async () => {
+  if (!conn) return
+  const msg = document.getElementById('msg').value
+  document.getElementById('msg').value = ''
+  log('me: ' + msg)
+  await conn.sink((async function * () { yield new TextEncoder().encode(msg) })())
+}
+</script>
+</body>
+</html>

--- a/go-libp2p-holepunch-services/worker/main.go
+++ b/go-libp2p-holepunch-services/worker/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -124,7 +123,6 @@ func createWorkerHost(ctx context.Context, listenPort int) (host.Host, error) {
 		libp2p.ListenAddrStrings(listenAddrs...),
 		libp2p.Transport(ws.New),
 		libp2p.EnableHolePunching(),
-		libp2p.EnableAutoRelay(),
 		libp2p.NATPortMap(),
 	)
 	if err != nil {

--- a/go-libp2p-holepunch-services/worker/main_test.go
+++ b/go-libp2p-holepunch-services/worker/main_test.go
@@ -4,23 +4,60 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	ws "github.com/libp2p/go-libp2p/p2p/transport/websocket"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
+)
+
+// Store for registered peers in tests.
+var (
+	testRegisteredPeers      = make(map[peer.ID]ma.Multiaddr)
+	testRegisteredPeersMutex = &sync.Mutex{}
 )
 
 // TestWorkerServiceRuns remains as placeholder if desired (removed duplicate tests)
 
 // simpleRegistrationHandlerForTest is used in tests to simulate rendezvous ACK.
+// It also now registers the peer to testRegisteredPeers for the listHandler to use.
 func simpleRegistrationHandlerForTest(s network.Stream) {
+	remotePeerID := s.Conn().RemotePeer()
+	remoteAddr := s.Conn().RemoteMultiaddr()
+
+	testRegisteredPeersMutex.Lock()
+	testRegisteredPeers[remotePeerID] = remoteAddr
+	testRegisteredPeersMutex.Unlock()
+
 	// Write ACK immediately so the client isn't blocked waiting.
 	_, _ = s.Write([]byte("ACK"))
 	// Drain any incoming data (optional) then close.
 	io.Copy(io.Discard, s)
 	_ = s.Close()
+}
+
+// listHandler for tests, mimics the rendezvous listHandler.
+func listHandler(s network.Stream) {
+	defer s.Close()
+	requester := s.Conn().RemotePeer()
+	testRegisteredPeersMutex.Lock()
+	defer testRegisteredPeersMutex.Unlock()
+
+	var peerAddrs []string
+	for pid, addr := range testRegisteredPeers {
+		if pid == requester {
+			continue
+		}
+		fullAddrStr := fmt.Sprintf("%s/p2p/%s", addr.String(), pid.String())
+		peerAddrs = append(peerAddrs, fullAddrStr)
+	}
+	_, _ = s.Write([]byte(strings.Join(peerAddrs, "\n") + "\n"))
 }
 
 // TestWorkerConnectsAndRegisters ensures worker connects to rendezvous and gets ACK.
@@ -52,8 +89,13 @@ func TestWorkerConnectsAndRegisters(t *testing.T) {
 
 // TestDiscoverPeersAndDial uses the list protocol to connect two workers via the rendezvous host.
 func TestDiscoverPeersAndDial(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+
+	// Clear the shared map for this test run
+	testRegisteredPeersMutex.Lock()
+	clear(testRegisteredPeers)
+	testRegisteredPeersMutex.Unlock()
 
 	rvHost, err := createWorkerHost(ctx, 0)
 	require.NoError(t, err)
@@ -61,30 +103,90 @@ func TestDiscoverPeersAndDial(t *testing.T) {
 	rvHost.SetStreamHandler(ProtocolIDForRegistration, simpleRegistrationHandlerForTest)
 	rvHost.SetStreamHandler(ProtocolIDForPeerList, listHandler)
 
-	w1, err := createWorkerHost(ctx, 0)
+	rvHostAddrInfo := peer.AddrInfo{
+		ID:    rvHost.ID(),
+		Addrs: rvHost.Addrs(),
+	}
+
+	// Create w1
+	w1, err := libp2p.New(
+		libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/tcp/0/ws"),
+		libp2p.Transport(ws.New),
+		libp2p.EnableHolePunching(),
+		libp2p.EnableAutoRelayWithStaticRelays([]peer.AddrInfo{rvHostAddrInfo}),
+		libp2p.NATPortMap(),
+	)
 	require.NoError(t, err)
 	defer w1.Close()
 
-	w2, err := createWorkerHost(ctx, 0)
+	// Create w2
+	w2, err := libp2p.New(
+		libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/tcp/0/ws"),
+		libp2p.Transport(ws.New),
+		libp2p.EnableHolePunching(),
+		libp2p.EnableAutoRelayWithStaticRelays([]peer.AddrInfo{rvHostAddrInfo}),
+		libp2p.NATPortMap(),
+	)
 	require.NoError(t, err)
 	defer w2.Close()
 
 	addrStr := fmt.Sprintf("%s/p2p/%s", rvHost.Addrs()[0], rvHost.ID())
+
+	// w1 registers. simpleRegistrationHandlerForTest will store its s.Conn().RemoteMultiaddr().
 	require.NoError(t, connectAndRegisterWithRendezvous(ctx, w1, addrStr))
+	// w2 registers. simpleRegistrationHandlerForTest will store its s.Conn().RemoteMultiaddr().
 	require.NoError(t, connectAndRegisterWithRendezvous(ctx, w2, addrStr))
 
-	peers, err := discoverPeersViaListProtocol(ctx, w1, addrStr)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(peers), 1)
-
-	// w1 should dial w2
-	var info peer.AddrInfo
-	for _, p := range peers {
-		if p.ID == w2.ID() {
-			info = p
+	// Now, OVERRIDE w2's entry in testRegisteredPeers with its actual listen address
+	// so that listHandler provides this correct address to w1.
+	var w2ListenAddrToUse ma.Multiaddr
+	for _, addr := range w2.Addrs() {
+		if strings.Contains(addr.String(), "/ip4/") && !strings.Contains(addr.String(), "127.0.0.1") {
+			w2ListenAddrToUse = addr
 			break
 		}
 	}
-	require.NotEqual(t, peer.ID(""), info.ID)
-	require.NoError(t, w1.Connect(ctx, info))
+	if w2ListenAddrToUse == nil {
+		for _, addr := range w2.Addrs() {
+			if strings.Contains(addr.String(), "/ip4/") {
+				w2ListenAddrToUse = addr
+				break
+			}
+		}
+	}
+	require.NotNil(t, w2ListenAddrToUse, "w2 has no suitable IPv4 listen address")
+
+	testRegisteredPeersMutex.Lock()
+	origW2Addr := testRegisteredPeers[w2.ID()] // The one from simpleRegistrationHandlerForTest
+	testRegisteredPeers[w2.ID()] = w2ListenAddrToUse
+	testRegisteredPeersMutex.Unlock()
+	t.Logf("Overrode w2 address for discovery. Was: %s, Now: %s", origW2Addr, w2ListenAddrToUse)
+
+	peers, err := discoverPeersViaListProtocol(ctx, w1, addrStr)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(peers), 1, "Should discover at least w2")
+
+	var w2Info peer.AddrInfo
+	foundW2 := false
+	for _, p := range peers {
+		if p.ID == w2.ID() {
+			w2Info = p
+			foundW2 = true
+			break
+		}
+	}
+	require.True(t, foundW2, "w2 not found in discovered peers")
+	require.NotEqual(t, peer.ID(""), w2Info.ID, "w2Info should be populated")
+	// Check that the address for w2 in w2Info is indeed the listen address we overrode with.
+	require.Len(t, w2Info.Addrs, 1, "w2Info should have one address from our map")
+	require.Equal(t, w2ListenAddrToUse.String(), w2Info.Addrs[0].String(), "w2Info address mismatch")
+
+	t.Logf("w1 (%s) attempting to connect to w2 (%s) with AddrInfo: %v", w1.ID(), w2.ID(), w2Info)
+	err = w1.Connect(ctx, w2Info)
+	if err != nil {
+		t.Logf("w1 addrs: %v", w1.Addrs())
+		t.Logf("w2 addrs: %v", w2.Addrs())
+		t.Logf("w2Info used for connect: %v", w2Info.Addrs)
+	}
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- create `webdemo/index.html` for a browser-based libp2p chat
- document the new demo in the Go services README

## Testing
- `go test` *(fails: download go toolchain)*